### PR TITLE
Fix issue with non-integer x-descriptors in srcset

### DIFF
--- a/htmLawed.php
+++ b/htmLawed.php
@@ -519,7 +519,7 @@ foreach($aA as $k=>$v){
    $v = str_replace("­", ' ', (strpos($v, '&') !== false ? str_replace(array('&#xad;', '&#173;', '&shy;'), ' ', $v) : $v)); # double-quoted char: soft-hyphen; appears here as "­" or hyphen or something else depending on viewing software
    if($k == 'srcset'){
     $v2 = '';
-    $pattern = "/(?:[^\"'\s]+\s*(?:\d+[wx])+)/";
+    $pattern = "/(?:[^\"'\s]+\s*(?:\d+w|\d+(?:\.\d+)?x)+)/";
     preg_match_all($pattern, $v, $matches);
     $matches = call_user_func_array('array_merge', $matches);
     foreach($matches as $k1=>$v1){


### PR DESCRIPTION
Example:
  `srcset="//example.com/a.jpg 1.5x, //example.com/b.jpg 2x"` resulted in
  `srcset="1.5x, //example.com/b.jpg 2x"`

Fixes https://github.com/wallabag/wallabag/issues/3852
